### PR TITLE
Fix unary operator expected error in run.sh

### DIFF
--- a/corr/run.sh
+++ b/corr/run.sh
@@ -57,7 +57,7 @@ fi
 cp -R "$masim_dir" "$ksft_abs_path/"
 
 damon_stat_enabled_file="/sys/module/damon_stat/parameters/enabled"
-if [ $(cat "$damon_stat_enabled_file") = "Y" ]
+if [[ $(cat "$damon_stat_enabled_file") = "Y" ]]
 then
 	echo "DAMON_STAT is running.  Disable for testing."
 	echo N > "$damon_stat_enabled_file"


### PR DESCRIPTION
corr/run: Fix unary operator expected error in run.sh
    
I ran into this warning when running the run.sh script,
    
cat: /sys/module/damon_stat/parameters/enabled: No such file or directory
./run.sh: line 60: [: =: unary operator expected ]
    
This is because on some systems where DAMON_STAT is not implemented, the file /sys/module/damon_stat/parameters/enabled does not exist.  Using cat command to read this non-existent file will result in an empty value in the equation.  This patch uses double brackets to resolve the issue of empty strings.