### PR TITLE
Upgrade the cross-compiler version for m68k

### DIFF
--- a/corr/tests/build_m68k.sh
+++ b/corr/tests/build_m68k.sh
@@ -45,8 +45,8 @@ echo 'CONFIG_MODULES=y' >> $ODIR/.config
 cat "$TESTDIR/damon_config" >> "$ODIR/.config"
 
 export COMPILER_INSTALL_PATH=$HOME/0day
-export COMPILER=gcc-7.5.0
-export URL=https://cdn.kernel.org/pub/tools/crosstool/files/bin/x86_64/7.5.0
+export COMPILER=gcc-8.1.0
+export URL=https://cdn.kernel.org/pub/tools/crosstool/files/bin/x86_64/8.1.0
 
 make.cross O=$ODIR ARCH=m68k olddefconfig
 make.cross O=$ODIR ARCH=m68k -j`grep -e '^processor' /proc/cpuinfo | wc -l`


### PR DESCRIPTION
I see the following warning when running the damon-tests with the latest Linux Kernel source,
    
     # make --keep-going CROSS_COMPILE=/root/0day/gcc-7.5.0-nolibc/m68k-linux/bin/m68k-linux- KCFLAGS= -Wno-error=return-type -Wreturn-type -funsigned-char -Wundef O=/root/linux/tools/testing/selftests/damon-tests/build_m68k.sh.out ARCH=m68k -j2
     # ***
     # *** C compiler is too old.
     # ***   Your GCC version:    7.5.0
     # ***   Minimum GCC version: 8.1.0
     # ***
     # scripts/Kconfig.include:45: Sorry, this C compiler is not supported.
    
This is because the upstream Linux kernel raised the minimum GCC version requirement to 8.1.0 starting from this commit [1].  Therefore, this patch upgrades the cross-compiler version in build_m68k.sh to prevent build failure.
    
[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=118c40b7b503
