### PR TITLE
Add Red Hat-based and SUSE-based distros support

### DIFF
--- a/corr/install_deps.sh
+++ b/corr/install_deps.sh
@@ -22,6 +22,11 @@ elif which dnf &> /dev/null; then
 	sudo dnf install -y make gcc gcc-c++ flex bison lftp gmp-devel \
 	libmpc-devel
 
+# SUSE-based distros
+elif which zypper &> /dev/null; then
+	sudo zypper install -y make gcc gcc-c++ flex bison bc lftp gmp-devel \
+	mpc-devel
+
 else
 	echo '#################################################################'
 	echo '# This distribution is not officially maintained by damon_tests #'

--- a/corr/install_deps.sh
+++ b/corr/install_deps.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
 
-# Basic requirements
-sudo apt install -y xz-utils lftp
+# Debian-based distros
+if which apt &> /dev/null; then
+	# Basic requirements
+	sudo apt install -y xz-utils lftp
 
-if ! sudo apt install -y python &> /dev/null
-then
-	# python package is not in Ubuntu 22.04
-	sudo apt install -y python-is-python3
+	if ! sudo apt install -y python &> /dev/null
+	then
+		# python package is not in Ubuntu 22.04
+		sudo apt install -y python-is-python3
+	fi
+
+	# Required for minimal installations in Ubuntu 22.04 and 24.04.
+	sudo apt install -y make gcc flex bison bc
+
+	# required from v6.11-rc1 for arm64 build
+	sudo apt install -y libgmp-dev libmpc-dev
+
+# Red Hat-based distros
+elif which dnf &> /dev/null; then
+	sudo dnf install -y make gcc gcc-c++ flex bison lftp gmp-devel \
+	libmpc-devel
+
+else
+	echo '#################################################################'
+	echo '# This distribution is not officially maintained by damon_tests #'
+	echo '# project.  You have to install required packages manually.     #'
+	echo '#################################################################'
 fi
-
-# Required for minimal installations in Ubuntu 22.04 and 24.04.
-sudo apt install -y make gcc flex bison bc
-
-# required from v6.11-rc1 for arm64 build
-sudo apt install -y libgmp-dev libmpc-dev


### PR DESCRIPTION
Currently, damon_tests only supports testing on Debian-based distros.  This patch set extends the support to Red Hat-based and SUSE-based distros, enabling broader test coverage.