### PR TITLE
corr: stop stale DAMON before masim-record test

### DIFF
--- a/corr/tests/masim-record.sh
+++ b/corr/tests/masim-record.sh
@@ -4,6 +4,8 @@
 ksft_skip=4
 
 TEST_DIR=$PWD
+# Stop any stale DAMON from previous tests
+sudo ./damo/damo stop 2>/dev/null
 
 if [ $EUID -ne 0 ]
 then


### PR DESCRIPTION
If a preceding test (e.g. schemes-filters in damo_tests.sh) leaves DAMON running, masim-record.sh fails immediately because 'damo record' cannot start a new kdamond while one is already active:

  $ ./damon-tests/corr/run.sh
  [...]
  not ok 9 selftests: damon-tests: masim-record.sh # exit=1
  could not turn DAMON on (Device or resource busy)

Add a defensive DAMON stop at the start of the script to tolerate incomplete cleanup by earlier tests.

Co-developed-by: Wang Lian <lianux.mm@gmail.com>
Signed-off-by: Kunwu Chan <kunwu.chan@gmail.com>